### PR TITLE
Fix marked content extraction

### DIFF
--- a/src/UglyToad.PdfPig/Content/MarkedContentElement.cs
+++ b/src/UglyToad.PdfPig/Content/MarkedContentElement.cs
@@ -109,7 +109,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"Index={Index}, MCID={MarkedContentIdentifier}, Tag={Tag}, Properties={Properties}, Contents={Children.Count}";
+            return $"Id={Index}, MCID={MarkedContentIdentifier}, Tag={Tag}, Properties={Properties}, Children={Children.Count}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -552,7 +552,8 @@
         {
             if (markedContentStack.CanPop)
             {
-                markedContents.Add(markedContentStack.Pop(pdfScanner));
+                var mc = markedContentStack.Pop(pdfScanner);
+                if (mc != null) markedContents.Add(mc);
             }
         }
 

--- a/src/UglyToad.PdfPig/Graphics/MarkedContentStack.cs
+++ b/src/UglyToad.PdfPig/Graphics/MarkedContentStack.cs
@@ -16,14 +16,14 @@
     {
         private readonly Stack<MarkedContentElementActiveBuilder> builderStack = new Stack<MarkedContentElementActiveBuilder>();
 
-        private int number;
+        private int number -1;
         private MarkedContentElementActiveBuilder top;
 
         public bool CanPop => top != null;
 
         public void Push(NameToken name, DictionaryToken properties)
         {
-            if (builderStack.Count > 0)
+            if (builderStack.Count == 0) // only increase index if root
             {
                 number++;
             }
@@ -42,6 +42,7 @@
             {
                 top = builderStack.Peek();
                 top.Children.Add(result);
+                return null; // do not return child
             }
             else
             {


### PR DESCRIPTION
Fix marked content extraction:
- only return root elements
- correct `Index` incrementation
- better `ToString()`

Prior to this fix, children and roots elements were returned as roots, and the index was only incremented when a child element was present